### PR TITLE
New-StoredCredential now returns username

### DIFF
--- a/Functions-PSStoredCredentials.ps1
+++ b/Functions-PSStoredCredentials.ps1
@@ -82,6 +82,9 @@ Function New-StoredCredential {
 
     $Credential.Password | ConvertFrom-SecureString | Out-File "$($KeyPath)\$($Credential.Username).cred" -Force
 
+    # Return a PSCredential object (with no password) so the caller knows what credential username was entered for future recalls
+    New-Object -TypeName System.Management.Automation.PSCredential($Credential.Username,(new-object System.Security.SecureString))
+
 }
 
 


### PR DESCRIPTION
Added functionality to return username as a PSCredential with a blank password. This will make programmatic use of the commands easier.

My use case is prompting the user for credentials first time (and I have no idea what the username will be), then storing that username for future recollection.